### PR TITLE
Fix wkt parser read infinite loop.

### DIFF
--- a/lib/src/com/hydrologis/dart_jts/io/io.dart
+++ b/lib/src/com/hydrologis/dart_jts/io/io.dart
@@ -1284,6 +1284,7 @@ class WKTTokenizer {
       } else {
         _lastReadToken =
             errorToken("unexpected character at <${currentToken()}>");
+        break;
       }
     }
     return _lastReadToken;


### PR DESCRIPTION
When reading tokens if the first character is an invalid character then the parser will infinate loop.